### PR TITLE
Results as datapackage default again

### DIFF
--- a/renpass/postprocessing.py
+++ b/renpass/postprocessing.py
@@ -45,11 +45,6 @@ def storage_net_results(path, label=[]):
         sep=";", date_format='%Y-%m-%dT%H:%M:%SZ')
 
 
-
-
-
-
-
 def connection_net_results(path, hubs=[]):
     """ Writes net results for connection components.
 
@@ -98,68 +93,3 @@ def _edges(nodes):
         for i in n.inputs:
             edges[str(n)].append((i, n))
     return edges
-
-# -----------------------------------------------------------------------
-# Derived results
-# -----------------------------------------------------------------------
-# transshipment / network export
-conns = _edges([n for n in es.nodes
-                if isinstance(n, facades.Connection)])
-
-data_path = os.path.join(
-    package_root_directory, 'data')
-if not os.path.exists(data_path):
-    os.makedirs(data_path)
-
-if conns:
-    transshipment = pd.concat(
-        [views.node(results, n, multiindex=True)['sequences'].\
-            loc[:, (n, slice(None), 'flow')]
-         for n in conns], axis=1)
-
-    net_transshipment = pd.concat([
-        transshipment.loc[:, (c, str(es.groups[c].from_bus), 'flow')] -
-        transshipment.loc[:, (c, str(es.groups[c].to_bus), 'flow')]
-        for c in conns], axis=1)
-    net_transshipment.columns = conns.keys()
-
-    net_transshipment.index.name = 'timeindex'
-    net_transshipment.to_csv(
-        os.path.join(data_path, 'transshipment.csv'),
-                     sep=";", date_format='%Y-%m-%dT%H:%M:%SZ')
-
-# storage output
-storages = {
-    n: views.node(results, n, multiindex=True)['sequences']
-    for n in es.nodes if isinstance(n, facades.Storage)}
-
-if storages:
-    storage_edges = _edges(storages.keys())
-    for k, v in storages.items():
-        # TODO: prettify column renaming
-        new_columns = []
-        for tup in tuple(v.columns):
-            if k == tup[0] and tup[2] == 'flow':
-                new_columns.append('output')
-            elif k == tup[1] and tup[2] == 'flow':
-                new_columns.append('input')
-            else:
-                new_columns.append('level')
-        v.columns = new_columns
-        net_storage = v.input - v.output
-        v.input = net_storage.apply(lambda row: row if row > 0 else 0)
-        v.output = net_storage.apply(lambda row: abs(row) if row < 0 else 0)
-        v.index.name = 'timeindex'
-        v.to_csv(
-            os.path.join(data_path, str(k) + '.csv'), sep=";",
-            date_format='%Y-%m-%dT%H:%M:%SZ')
-
-# TODO prettify / complete package (meta-data) creation
-if arguments['--results'] == 'datapackage':
-    # results package (rp)
-    rp = Package()
-    rp.infer(os.path.join(package_root_directory, 'data', '**/*.csv'))
-    rp.descriptor['description'] = "Model results from renpass with version..."
-    rp.descriptor['name'] = modelname + '-results'
-    rp.commit()
-    rp.save(os.path.join(package_root_directory, 'datapackage.json'))

--- a/renpass/renpass.py
+++ b/renpass/renpass.py
@@ -243,7 +243,22 @@ def write_results(es, m, p, **arguments):
     logging.info('Exporting results to {}'.format(
         os.path.abspath(output_base_directory)))
 
-    _write_results(es, results, path=output_base_directory, model=m)
+    output_directory = os.path.join(
+        output_base_directory, arguments['--output-orient'] + '-orient')
+
+    os.makedirs(output_directory, exist_ok=True)
+
+    _write_results(es, results, path=output_directory, model=m)
+
+    if arguments['--results'] == 'datapackage':
+        rp = Package()
+        rp.infer(os.path.join(output_directory, '**/*.csv'))
+        rp.descriptor['description'] = \
+            'Model results from renpass with version {}'.format(
+                arguments['--version'])
+        rp.descriptor['name'] = modelname + '-results'
+        rp.commit()
+        rp.save(os.path.join(output_directory, 'datapackage.json'))
 
     return True
 
@@ -272,7 +287,10 @@ def main(**arguments):
 ###############################################################################
 
 if __name__ == '__main__':
-    arguments = docopt(__doc__, version='renpass v0.2')
+
+    ver = 'renpass v0.2'
+    arguments = docopt(__doc__, version=ver)
+    arguments.update({'--version': ver})
 
     logger.define_logging(logpath=arguments['--output-directory'])
 


### PR DESCRIPTION
Inferring a datapackage from stored results is part of the main executable again using the --results cli option. For each result orientation a separate folder is created and a datapackage.json is written. I don't know if thats a nice way to do it, but imo working with results it's a benefit to be able to reference a datapackage without further csv-handling although result representation might change again.